### PR TITLE
[BUGFIX] Determine width only in regular terminal

### DIFF
--- a/Classes/Command/AbstractCommandController.php
+++ b/Classes/Command/AbstractCommandController.php
@@ -39,7 +39,7 @@ if (DIRECTORY_SEPARATOR !== '\\') {
 }
 
 // Get terminal width
-if (@exec('tput cols')) {
+if (getenv('TERM') && @exec('tput cols')) {
     define('TERMINAL_WIDTH', exec('tput cols'));
 } else {
     define('TERMINAL_WIDTH', 79);


### PR DESCRIPTION
Within certain environments, e.g. CI servers no regular terminal
is exposed, thus `tput` doesn't work well.

Fixes #8
