### PR TITLE
TYPO3 8 support

### DIFF
--- a/Documentation/UserManual/Index.rst
+++ b/Documentation/UserManual/Index.rst
@@ -13,7 +13,7 @@ User Manual
 
 The import and export tasks can be long running processes. Therefore they are executed using the command line dispatcher.
 
-You can execute the dispathcer from the root of your website:
+You can execute the dispatcher from the root of your website:
 
 .. code-block:: bash
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "GPL-2.0+"
   ],
   "require": {
-    "typo3/cms": "6.2 - 7.6",
+    "typo3/cms-core": ">=6.2.0,<8.5.0",
     "symfony/yaml": "2.6 - 3.99"
   },
   "replace": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -35,7 +35,7 @@ $EM_CONF[$_EXTKEY] = array(
     'version' => '1.0.10',
     'constraints' => array(
         'depends' => array(
-            'typo3' => '6.2.0-7.99.99',
+            'typo3' => '6.2.0-8.4.99',
         ),
         'conflicts' => array(),
         'suggests' => array(),


### PR DESCRIPTION
Update the upper version constraint for supporting TYPO3 8.4.

I tested the basic commands, but I must confess, I don't know if there are some things which must be tested.

If could provide further PRs if I find some breaking stuff.
