### PR TITLE
[BUGFIX] ExportCommand: Add also values like "0"

### DIFF
--- a/Classes/Command/ExportCommandController.php
+++ b/Classes/Command/ExportCommandController.php
@@ -196,7 +196,7 @@ class ExportCommandController extends AbstractCommandController
                     $explodedValue = explode(',', $value);
                     if (count($explodedValue) > 1) {
                         $explodedRow[$column] = $explodedValue;
-                    } elseif ($value) {
+                    } elseif (strlen($value)) {
                         $explodedRow[$column] = $value;
                     }
                 }


### PR DESCRIPTION
Add a strlen() while iterating over each column.

This fix e.g. an export of be_group records where `allowed_languages` has the value `0`.