### PR TITLE
fix TYPO3 9.5 compatibility; raise requirements to TYPO3 ^8.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "GPL-2.0"
   ],
   "require": {
-    "typo3/cms-core": "^6.2 || ^8.7 || ^9.5",
+    "typo3/cms-core": "^8.7 || ^9.5",
     "symfony/yaml": "2.6 - 4.99"
   },
   "replace": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -35,7 +35,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '1.0.12',
     'constraints' => [
         'depends' => [
-            'typo3' => '6.2.0-9.5.99',
+            'typo3' => '8.7.0-9.5.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
use ConnectionPool / QueryBuilder for database Connections
this breaks compatiblity for everything older then ^8.7 as there was
no query builder

Signed-off-by: Christian Wolff <cwolff@aer.de>